### PR TITLE
Update URL to wpcs repo

### DIFF
--- a/modules/phpcs/manifests/init.pp
+++ b/modules/phpcs/manifests/init.pp
@@ -45,7 +45,7 @@ class phpcs (
 		}
 
 		exec { 'wordpress cs install':
-			command => 'git clone -b master https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git /vagrant/extensions/phpcs/wpcs && phpcs --config-set installed_paths /vagrant/extensions/phpcs/wpcs',
+			command => 'git clone -b master https://github.com/WordPress/WordPress-Coding-Standards.git /vagrant/extensions/phpcs/wpcs && phpcs --config-set installed_paths /vagrant/extensions/phpcs/wpcs',
 			path    => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
 			require => [ Package['git-core'], Exec['phpcs install'], File['/vagrant/extensions/phpcs/wpcs'] ]
 		}


### PR DESCRIPTION
I just edited the file directly on github - so it's untested. Feel free to close this and fix separately as I messed up the commit message

Fixes ```    default: Error: 'git clone -b master https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git /vagrant/extensions/phpcs/wpcs && phpcs --config-set installed_paths /vagrant/extensions/phpcs/wpcs' returned 128 instead of one of [0]
    default: Error: /Stage[main]/Phpcs/Exec[wordpress cs install]/returns: change from 'notrun' to ['0'] failed: 'git clone -b master https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git /vagrant/extensions/phpcs/wpcs && phpcs --config-set installed_paths /vagrant/extensions/phpcs/wpcs' returned 128 instead of one of [0]```